### PR TITLE
Добавил версию products для планшета.

### DIFF
--- a/src/partials/products.html
+++ b/src/partials/products.html
@@ -1,18 +1,15 @@
 <section class="products">
     <div class="products-wrap container">
-        <div class="products-title">
-            <h2 class="products-title-part-1">100% natural</h2>
-            <h3 class="products-title-part-2">products</h3>
-        </div>
+
+        <h2 class="products-title">100% natural</h2>
+        <h3 class="products-title subtitle">products</h3>
+
 
         <ul class="products-list">
 
             <li class="product">
 
-                <picture class="product-image">
-                    <source srcset="./images/icecream.png 1x, ./images/icecream@2x.png 2x" type="image/png">
-                    <img src="./images/icecream.png" width="250" alt="Ice Cream">
-                </picture>
+                <img class="product-image" srcset="./images/icecream.png 1x, ./images/icecream@2x.png 2x" src="./images/icecream.png" width="250" alt="Ice Cream" />
 
                 <ul class="product-info">
 
@@ -25,7 +22,7 @@
                     <li class="product-info-item">
                         <p class="product-info-description">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
                             do
-                            eiusmod tempor incididunt ut labore et. dolore magna aliqua facilisis.</p>
+                            eiusmod tempor incididunt ut labore et.</p>
                     </li>
                     <li class="product-info-item">
                         <a class="product-info-link" href="">
@@ -39,15 +36,12 @@
             </li>
             <li class="product">
 
-                <picture class="product-image">
-                    <source srcset="./images/icecoffee.png 1x, ./images/icecoffee@2x.png 2x" type="image/png">
-                    <img src="./images/icecoffee.png" width="250" alt="Ice Cream">
-                </picture>
+                <img class="product-image" srcset="./images/icecoffee.png 1x, ./images/icecoffee@2x.png 2x" src="./images/icecoffee.png" width="250" alt="Ice Coffee"/>
 
                 <ul class="product-info">
 
                     <li class="product-info-item">
-                        <p class="product-info-title">ice cream</p>
+                        <p class="product-info-title">ice coffee</p>
                     </li>
                     <li class="product-info-item">
                         <img class="dotts" src="./images/dotts.png" alt="" width="26">
@@ -55,7 +49,7 @@
                     <li class="product-info-item">
                         <p class="product-info-description">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
                             do
-                            eiusmod tempor incididunt ut labore et. dolore magna aliqua facilisis.</p>
+                            eiusmod tempor incididunt ut labore et.</p>
                     </li>
                     <li class="product-info-item">
                         <a class="product-info-link" href="">
@@ -69,15 +63,12 @@
             </li>
             <li class="product">
 
-                <picture class="product-image">
-                    <source srcset="./images/milkshakes.png 1x, ./images/milkshakes@2x.png 2x" type="image/png">
-                    <img src="./images/milkshakes.png" width="250" alt="Ice Cream">
-                </picture>
+                <img class="product-image" srcset="./images/milkshakes.png 1x, ./images/milkshakes@2x.png 2x" src="./images/milkshakes.png" width="250" alt="Milkshakes" />
 
                 <ul class="product-info">
 
                     <li class="product-info-item">
-                        <p class="product-info-title">ice cream</p>
+                        <p class="product-info-title">milkshakes</p>
                     </li>
                     <li class="product-info-item">
                         <img class="dotts" src="./images/dotts.png" alt="" width="26">
@@ -85,7 +76,7 @@
                     <li class="product-info-item">
                         <p class="product-info-description">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
                             do
-                            eiusmod tempor incididunt ut labore et. dolore magna aliqua facilisis.</p>
+                            eiusmod tempor incididunt ut labore et.</p>
                     </li>
                     <li class="product-info-item">
                         <a class="product-info-link" href="">

--- a/src/sass/components/_products.scss
+++ b/src/sass/components/_products.scss
@@ -9,36 +9,57 @@ p {
 }
 
 .products {
-  padding-top: 121px;
-  padding-bottom: 98px;
+  padding-top: 120px;
+  padding-bottom: 100px;
   width: 100%;
 
-  &-wrap {
-    padding-right: 20px;
-    padding-left: 20px;
+  @media screen and (min-width: 768px) {
+    padding-bottom: 110px;
   }
 
   &-title {
     text-align: center;
-    margin-bottom: 31px;
     text-transform: uppercase;
 
-    &-part-1 {
-      margin-bottom: 15px;
+    &.subtitle {
+      margin-top: 30px;
+
+      @media screen and (min-width: 768px) {
+        margin-bottom: 40px;
+      }
+    }
+  }
+
+  &-list {
+    display: flex;
+    flex-wrap: wrap;
+    margin-top: 145px;
+
+    @media screen and (min-width: 768px) {
+      margin-top: 150px;
     }
   }
 }
 
 .product {
   position: relative;
-  margin-top: 130px;
   border-radius: 24px;
   display: flex;
   flex-direction: column;
   align-items: center;
 
-  &:not(:last-child) {
-    margin-bottom: 16px;
+  @media screen and (min-width: 768px) {
+    width: calc((100% - 40px) / 3);
+
+    &:not(:last-child) {
+      margin-right: 20px;
+    }
+  }
+
+  @media screen and (max-width: 767px) {
+    &:not(:last-child) {
+      margin-bottom: 130px;
+    }
   }
 
   &:nth-child(1) {
@@ -59,7 +80,10 @@ p {
     flex-direction: column;
     align-items: center;
     padding: 160px 40px 40px;
-    // border-radius: 24px;
+
+    @media screen and (min-width: 768px) {
+      padding: 152px 11px 40px;
+    }
 
     &-description {
       font-weight: 700;
@@ -68,6 +92,15 @@ p {
       text-align: center;
       letter-spacing: 0.04em;
       color: $primary-text-color;
+
+      @media screen and (min-width: 768px) {
+        line-height: 1.76;
+        height: 124px;
+      }
+
+      @media screen and (min-width: 1200px) {
+        font-size: 16px;
+      }
     }
 
     &-title {
@@ -90,6 +123,10 @@ p {
       width: 40px;
       height: 40px;
 
+      @media screen and (min-width: 768px) {
+        margin-top: 10px;
+      }
+
       .arrow {
         fill: $accent-color;
       }
@@ -104,5 +141,9 @@ p {
     z-index: 2;
     position: absolute;
     top: -114px;
+
+    @media screen and (min-width: 768px) {
+      top: -104px;
+    }
   }
 }

--- a/src/sass/utils/_base.scss
+++ b/src/sass/utils/_base.scss
@@ -2,6 +2,15 @@ body {
   font-family: $primary-font;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+}
+
 ul {
   padding: 0;
   margin: 0;


### PR DESCRIPTION
- Сброс маржинов у заголовков перенёс в _base.sass. 

- Убрал падинги у -wrap. Этот класс нужен - на него вешается container. Верхний и нижний отступ от соседних секций вешается на саму секцию - products.

- Убрал заголовки секции из div.

- product-info обернул в список для удобного центрирования флексом и для удобства дачи елементам product-info отступов (они одинаковые).

- Picture заменил обычным img.

- Сделал правильны отступ карточек от заголовка секции (раньше отступал маржином самой карточки, пробивая родительский блок ul.

- Убрал лишние слова в мобильной версии.